### PR TITLE
Ignore the TabletopClub folder created when running the game through the

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ game/webrtc/
 
 # OSX ignores
 .DS_Store
+
+# Project-specific ignores
+game/TabletopClub/


### PR DESCRIPTION
**Fixes/Solves**
This is a bit of a niche ignore, so feel free to close this.

When running the game through the Godot editor the TabletopClub folder with saves and assets is created inside the repository, if the system cannot determine the correct DOCUMENTS folder.
The folder is the shown in `git status` and might be added by accident. The ignore should prevent this.

A bit dangerous if you ever plan to have an actual TabletopClub folder inside the game repository.