### PR TITLE
Refactored AssetDB config file search to allow more wildcards

### DIFF
--- a/docs/custom_assets/asset_packs/asset_pack_structure.rst
+++ b/docs/custom_assets/asset_packs/asset_pack_structure.rst
@@ -100,15 +100,19 @@ Here is an example of a ``config.cfg`` file:
 
    ; The following properties apply only to objects whose name start with
    ; "Heavy". These properties take precedence over the properties under [*].
+   ; The wildcard * can either be at the beginning and/or at the end.
    [Heavy*]
+
+   ; This is equivalent to 100g.
+   mass = 100.0
+
+   ; Similar to [Heavy*] this applies only to objects whose name end with "Info.png".
+   [*Info.png]
 
    ; Descriptions can be on multiple lines.
    desc = "This is one line,
 
    and this is another!"
-
-   ; This is equivalent to 100g.
-   mass = 100.0
 
    ; The following properties apply only to the given object.
    [Temporary.png]


### PR DESCRIPTION
**Fixes/Solves**
The AssetDB config search was done via an recursive call. This is usually slow.

I tried to refactor the `_get_file_config_value` function. I tried two methods:
- Using a regex
- Using a normal string find

Both methods would allow different wildcards for the config file:
- Regex would allow any amount of wildcards anywhere
- String find only on the right or left side

I compared the loading times:
- Default: ~ 305ms
- Regex: ~ 405ms
- Find: ~ 260ms

Assets used:
- Default pack
- additionally 80 custom cards

While I would like a regex approach I don't think it is worth sacrificing loading times. Especially with loarget packs and more assets, it will take even longer.

Using the find method we are: faster, don't have a recursive call, and would be able to use wildcards at the beginning:
- "My_Card_b.png"
- "*_b.png"
- "My_Card*"
All 3 combinations would work.

The method I used is:
- Go over all sections and see if the sections name is inside the file name
- Sort the results (shortest to longest) - longest should obviously be the exact name match
- call config.get_value with all possibilities from generic (*) to specific (exact match)


What are your thoughts about this?

Would solve #146
