### PR TITLE
Doubleclick in previews to trigger action

### DIFF
--- a/game/Scenes/Game/UI/Previews/GenericPreview.tscn
+++ b/game/Scenes/Game/UI/Previews/GenericPreview.tscn
@@ -7,6 +7,7 @@
 [node name="GenericPreview" type="PanelContainer"]
 margin_right = 119.0
 margin_bottom = 104.0
+mouse_filter = 1
 script = ExtResource( 3 )
 __meta__ = {
 "_editor_description_": "This preview is used to display basic assets. It displays the name and description, and the texture if the asset points to one."

--- a/game/Scenes/Game/UI/Previews/PreviewFilter.tscn
+++ b/game/Scenes/Game/UI/Previews/PreviewFilter.tscn
@@ -61,6 +61,7 @@ margin_top = 34.0
 margin_right = 632.0
 margin_bottom = 434.0
 rect_min_size = Vector2( 620, 400 )
+mouse_filter = 1
 size_flags_vertical = 3
 scroll_horizontal_enabled = false
 

--- a/game/Scripts/Game/UI/Dialogs/PreviewDialog.gd
+++ b/game/Scripts/Game/UI/Dialogs/PreviewDialog.gd
@@ -41,6 +41,11 @@ func reconfigure() -> void:
 func _ready():
 	_preview_filter.db_types = db_types
 	_load_button.text = load_button_text
+	connect("gui_input", self, "_on_gui_input")
+	
+func _on_gui_input(event):
+	if event is InputEventMouseButton and event.pressed and event.doubleclick and event.button_index == BUTTON_LEFT:
+		_on_LoadButton_pressed()
 
 func _on_LoadButton_pressed():
 	var previews_selected = get_tree().get_nodes_in_group("preview_selected")

--- a/game/Scripts/Game/UI/Dialogs/SaveDialog.gd
+++ b/game/Scripts/Game/UI/Dialogs/SaveDialog.gd
@@ -58,6 +58,13 @@ var _context_file_entry: Dictionary = {}
 
 var _save_preview = preload("res://Scenes/Game/UI/Previews/GenericPreview.tscn")
 
+func _ready():
+	connect("gui_input", self, "_on_gui_input")
+	
+func _on_gui_input(event):
+	if event is InputEventMouseButton and event.pressed and event.doubleclick and event.button_index == BUTTON_LEFT:
+		_on_load_save_button_pressed()
+
 # Clear the list of saves.
 func clear() -> void:
 	for preview in _save_container.get_children():
@@ -181,6 +188,7 @@ func _init():
 	
 	var scroll_container = ScrollContainer.new()
 	scroll_container.size_flags_vertical = SIZE_EXPAND_FILL
+	scroll_container.mouse_filter = Control.MOUSE_FILTER_PASS
 	top_container.add_child(scroll_container)
 	
 	_save_container = VBoxContainer.new()

--- a/game/Scripts/Game/UI/Previews/Preview.gd
+++ b/game/Scripts/Game/UI/Previews/Preview.gd
@@ -103,7 +103,11 @@ func _on_gui_input(event):
 			var ctrl = event.command if OS.get_name() == "OSX" else event.control
 			if not (allow_multiple_select and ctrl):
 				get_tree().call_group("preview_selected", "set_selected", false)
-			set_selected(not is_selected())
+			if event.doubleclick:
+				get_tree().call_group("preview_selected", "set_selected", true)
+				set_selected(true)
+			else:
+				set_selected(not is_selected())
 
 func _on_visibility_changed():
 	set_selected(false)

--- a/game/Scripts/Game/UI/Previews/Preview.gd
+++ b/game/Scripts/Game/UI/Previews/Preview.gd
@@ -65,12 +65,25 @@ func set_selected(selected: bool) -> void:
 	if not selectable:
 		return
 	
-	if selected and (not is_in_group("preview_selected")):
+	if selected and not is_selected():
 		add_to_group("preview_selected")
-	elif (not selected) and is_in_group("preview_selected"):
+	elif (not selected) and is_selected():
 		remove_from_group("preview_selected")
 	
 	_set_selected_gui(selected)
+
+# Set the preview as selected.
+# Will unselect all other previews.
+func set_selected_single() -> void:
+	if not selectable:
+		return
+	
+	if is_selected():
+		remove_from_group("preview_selected")
+	
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_REALTIME , "preview_selected", "set_selected", false)
+	
+	set_selected(true)
 
 func _ready():
 	connect("gui_input", self, "_on_gui_input")
@@ -101,13 +114,10 @@ func _on_gui_input(event):
 		# If the preview has been clicked, register it as selected.
 		if event.pressed and event.button_index == BUTTON_LEFT:
 			var ctrl = event.command if OS.get_name() == "OSX" else event.control
-			if not (allow_multiple_select and ctrl):
-				get_tree().call_group("preview_selected", "set_selected", false)
-			if event.doubleclick:
-				get_tree().call_group("preview_selected", "set_selected", true)
-				set_selected(true)
-			else:
+			if allow_multiple_select and ctrl:
 				set_selected(not is_selected())
+			else:
+				set_selected_single()
 
 func _on_visibility_changed():
 	set_selected(false)


### PR DESCRIPTION
**Fixes/Solves**
While I was create an asset pack, I was adding cards to the game quite often. Clicking on the card an add is quite tedious after a while.
Also a double click on an item is usually an enter action in many games / GUIs.

So I tried to implement a double click action for these. The double click action now works for:
- Objects (to add)
- Games (to load)
- Room (to select, apply has to be hit manually still)
- Loading Savegames
- Saving Savegames

