### PR TITLE
Fixed resetting type filter when changing packs

### DIFF
--- a/game/Scripts/Game/UI/Previews/PreviewFilter.gd
+++ b/game/Scripts/Game/UI/Previews/PreviewFilter.gd
@@ -203,6 +203,8 @@ func _filter_previews(from_filtered: bool) -> void:
 
 # Set the items in the type option button.
 func _set_type_options() -> void:
+	# Remember current selection
+	var selected_type = _type_button.get_item_text(_type_button.selected)
 	_type_button.clear()
 	
 	if _pack_button.get_item_count() == 0:
@@ -246,6 +248,12 @@ func _set_type_options() -> void:
 			
 			_type_button.add_item(type_text)
 			_type_button.set_item_metadata(_type_button.get_item_count() - 1, type_display)
+	
+	# Set the selection to the same type, if the type exists in the current pack
+	for i in range(_type_button.get_item_count()):
+		if _type_button.get_item_text(i) == selected_type:
+			_type_button.select(i)
+			break
 
 # Update the preview GUI.
 func _update_preview_gui() -> void:
@@ -296,6 +304,8 @@ func _on_ObjectPreviewGrid_requesting_objects(start: int, length: int):
 	_object_preview_grid.provide_objects(previews, after)
 
 func _on_PackButton_item_selected(_index: int):
+	# Pack changed, reset types to only show available types and update displayed previews
+	_set_type_options()
 	_display_previews()
 
 func _on_SearchEdit_text_changed(new_text: String):


### PR DESCRIPTION
**Fixes/Solves**
I noticed that the PreviewFilter.gd `_set_type_options` sets the types only to the ones available in the selected pack.
This was not the case because the function was not called when the pack was changed.

The selected type is remembered and set again if it is available in the new selected pack.
