### PR TITLE
Set linear_velocity.y to 0 when stop hovering to avoid pieces to fly away

### DIFF
--- a/game/Scripts/Game/Pieces/Piece.gd
+++ b/game/Scripts/Game/Pieces/Piece.gd
@@ -513,6 +513,11 @@ remotesync func stop_hovering() -> void:
 	collision_layer = 1
 	sleeping = false
 	
+	# If the piece is still in the process to reach its hover position, the
+	# velocity in Y would let it fly away. Tossing pieces are not using the Y
+	# axis either, so we reset it to 0
+	linear_velocity.y = 0
+	
 	# Only the server gets to turn off the custom integrator, since it is the
 	# authority for the physics simulation.
 	if get_tree().is_network_server():


### PR DESCRIPTION
**Fixes/Solves**
Fixes #166 

When a piece is trying to reach its hovering position, but you let go off the mouse button, the linear_velocity is kept for future physic processes. This leads to the piece flying very very high (until it reaches HELL).

I set the linear_velocity in Y to 0 when we stop hovering. This fixes the issue. Tossing an object does not modify it's Y axis so it shouldn't break any other behavior.
