### PR TITLE
Added an "All" filter for Packs and Types

### DIFF
--- a/game/Scripts/Game/UI/Previews/PreviewFilter.gd
+++ b/game/Scripts/Game/UI/Previews/PreviewFilter.gd
@@ -34,6 +34,8 @@ onready var _generic_preview_grid = $ScrollContainer/VBoxContainer/GenericPrevie
 export(Dictionary) var db_types = {} setget set_db_types
 
 const DEFAULT_ASSET_PACK = "TabletopClub"
+const ALL_PACKS_METADATA = "@ALL_PACKS_DISPLAY"
+const ALL_TYPES_METADATA = "@ALL_TYPES_DISPLAY"
 const GENERIC_PREVIEW_TYPES = [
 	"games",
 	"music",
@@ -63,6 +65,11 @@ func display_previews() -> void:
 # Returns: The currently selected pack.
 func get_pack() -> String:
 	return _pack_button.get_item_text(_pack_button.selected)
+
+# Get the current metadata of the selected pack
+# Returns: The current metadata of the selected pack
+func get_pack_metadata() -> String:
+	return _pack_button.get_item_metadata(_pack_button.selected)
 
 # Get the currently selected type.
 # Returns: The currently selected type.
@@ -102,7 +109,7 @@ func setup() -> void:
 	_pack_button.clear()
 	
 	_pack_button.add_item(tr("All"))
-	_pack_button.set_item_metadata(_pack_button.get_item_count() - 1, "ALL_PACKS_DISPLAY")
+	_pack_button.set_item_metadata(_pack_button.get_item_count() - 1, ALL_PACKS_METADATA)
 	_pack_button.add_separator()
 	
 	var asset_db = AssetDB.get_db()
@@ -146,7 +153,7 @@ func _display_previews() -> void:
 		return
 	
 	var asset_db = AssetDB.get_db()
-	var is_pack_all = bool(_pack_button.get_item_metadata(_pack_button.selected) == "ALL_PACKS_DISPLAY")
+	var is_pack_all = bool(get_pack_metadata() == ALL_PACKS_METADATA)
 	var packs = []
 	if is_pack_all:
 		packs = asset_db.keys()
@@ -155,7 +162,7 @@ func _display_previews() -> void:
 	
 	var use_generic_grid = false
 	var type_display = get_type()
-	var is_type_all = bool(type_display == "ALL_TYPES_DISPLAY")
+	var is_type_all = bool(type_display == ALL_TYPES_METADATA)
 	for pack in packs:
 		if not asset_db.has(pack):
 			continue
@@ -233,7 +240,7 @@ func _set_type_options() -> void:
 		return
 	
 	var asset_db = AssetDB.get_db()
-	var is_pack_all = bool(_pack_button.get_item_metadata(_pack_button.selected) == "ALL_PACKS_DISPLAY")
+	var is_pack_all = bool(get_pack_metadata() == ALL_PACKS_METADATA)
 	var pack = get_pack()
 	# The default asset pack has every type, so use the DEFAULT_ASSET_PACK
 	# as reference
@@ -282,7 +289,7 @@ func _set_type_options() -> void:
 	# An "All" filter makes only sense if we have more than 1 type.
 	if type_texts.size() > 1:
 		_type_button.add_item(tr("All"))
-		_type_button.set_item_metadata(_type_button.get_item_count() - 1, "ALL_TYPES_DISPLAY")
+		_type_button.set_item_metadata(_type_button.get_item_count() - 1, ALL_TYPES_METADATA)
 	for i in range(type_texts.size()):
 		_type_button.add_item(type_texts[i])
 		_type_button.set_item_metadata(_type_button.get_item_count() - 1, type_displays[i])

--- a/game/Scripts/Game/UI/Previews/PreviewFilter.gd
+++ b/game/Scripts/Game/UI/Previews/PreviewFilter.gd
@@ -101,17 +101,20 @@ func set_db_types(types: Dictionary) -> void:
 func setup() -> void:
 	_pack_button.clear()
 	
-	_pack_button.add_item("All")
+	_pack_button.add_item(tr("All"))
+	_pack_button.set_item_metadata(_pack_button.get_item_count() - 1, "ALL_PACKS_DISPLAY")
 	_pack_button.add_separator()
 	
 	var asset_db = AssetDB.get_db()
 	if asset_db.has(DEFAULT_ASSET_PACK):
 		_pack_button.add_item(DEFAULT_ASSET_PACK)
+		_pack_button.set_item_metadata(_pack_button.get_item_count() - 1, DEFAULT_ASSET_PACK)
 		_pack_button.add_separator()
 	
 	for pack in asset_db:
 		if pack != DEFAULT_ASSET_PACK:
 			_pack_button.add_item(pack)
+			_pack_button.set_item_metadata(_pack_button.get_item_count() - 1, pack)
 	
 	if _is_ready:
 		_set_type_options()
@@ -143,16 +146,16 @@ func _display_previews() -> void:
 		return
 	
 	var asset_db = AssetDB.get_db()
-	var selected_pack = get_pack()
+	var is_pack_all = bool(_pack_button.get_item_metadata(_pack_button.selected) == "ALL_PACKS_DISPLAY")
 	var packs = []
-	if selected_pack == "All":
+	if is_pack_all:
 		packs = asset_db.keys()
 	else:
-		packs.append(selected_pack)
+		packs.append(get_pack())
 	
 	var use_generic_grid = false
 	var type_display = get_type()
-	var is_type_all = bool(type_display == "ALL")
+	var is_type_all = bool(type_display == "ALL_TYPES_DISPLAY")
 	for pack in packs:
 		if not asset_db.has(pack):
 			continue
@@ -230,10 +233,11 @@ func _set_type_options() -> void:
 		return
 	
 	var asset_db = AssetDB.get_db()
+	var is_pack_all = bool(_pack_button.get_item_metadata(_pack_button.selected) == "ALL_PACKS_DISPLAY")
 	var pack = get_pack()
 	# The default asset pack has every type, so use the DEFAULT_ASSET_PACK
 	# as reference
-	if pack == "All":
+	if is_pack_all:
 		pack = DEFAULT_ASSET_PACK
 	if not asset_db.has(pack):
 		return
@@ -277,8 +281,8 @@ func _set_type_options() -> void:
 	
 	# An "All" filter makes only sense if we have more than 1 type.
 	if type_texts.size() > 1:
-		_type_button.add_item("All")
-		_type_button.set_item_metadata(_type_button.get_item_count() - 1, "ALL")
+		_type_button.add_item(tr("All"))
+		_type_button.set_item_metadata(_type_button.get_item_count() - 1, "ALL_TYPES_DISPLAY")
 	for i in range(type_texts.size()):
 		_type_button.add_item(type_texts[i])
 		_type_button.set_item_metadata(_type_button.get_item_count() - 1, type_displays[i])


### PR DESCRIPTION
**Fixes/Solves**
Fixes #141 

I thought about adding an "All" type to the AssetDB - but since this is an "UI" element only I don't think this belongs into the AssetDB.

The idea is that there is an "All" pack that displays all packs. This is available in all PreviewFilter instances and selected by default.

I also added an "All" filter for types. This is beneficial if you use the search function to filter. Or to see all assets in one go. Also selected by default.
There is an additional condition for types: the "All" filter will only be created if there is more than 1 type. So for instances like table, skybox etc there won't be an "All" type filter.
