### PR TITLE
Dice: Backport 0.2.0 face_values format (kinda)

### DIFF
--- a/docs/custom_assets/asset_packs/asset_types.rst
+++ b/docs/custom_assets/asset_packs/asset_types.rst
@@ -112,7 +112,7 @@ orientation in the :ref:`config-cfg` file, using the ``face_values`` property:
    face_values = {
 
       ; This is the format of an entry in face_values:
-      ; A number, followed by a semi-colon, followed by a Vector2, with two
+      ; A number, followed by a semi-colon, followed by a Vector2 (or list of Vector2s). Each Vector2 has two
       ; numbers inside, followed by a comma if it is not the last entry.
       1: Vector2(0.0, 0.0),
 
@@ -136,6 +136,7 @@ dice. The total will be shown at the top of the context menu.
 If ``face_values`` is not configured, the dice will always report ``0`` as its
 value.
 
+If the same value needs to be present on multiple faces, a list may be specified rather than a single Vector2, as so:  ``-1: [Vector2(0.0, 0.0), Vector2(180.0, 0.0)]``
 
 .. _object-type-piece:
 

--- a/docs/custom_assets/asset_packs/asset_types.rst
+++ b/docs/custom_assets/asset_packs/asset_types.rst
@@ -112,8 +112,8 @@ orientation in the :ref:`config-cfg` file, using the ``face_values`` property:
    face_values = {
 
       ; This is the format of an entry in face_values:
-      ; A number, followed by a semi-colon, followed by a Vector2 (or list of Vector2s). Each Vector2 has two
-      ; numbers inside, followed by a comma if it is not the last entry.
+      ; A number, followed by a semi-colon, followed by a Vector2. Each Vector2
+      ; has two numbers inside, followed by a comma if it is not the last entry.
       1: Vector2(0.0, 0.0),
 
       ; The two numbers inside the Vector2 correspond to the rotation in the
@@ -126,7 +126,12 @@ orientation in the :ref:`config-cfg` file, using the ``face_values`` property:
       3: Vector2(-90.0, 0.0),
       4: Vector2(90.0, 0.0),
       5: Vector2(0.0, -90.0),
-      6: Vector2(180.0, 0.0)
+
+      ; Alternatively, the Vector2 and the number may swap places.
+      ; This allows multiple rotations with the same value.
+      ; Values given this way may be null, numbers, or strings.
+      ; Values that can't be parsed as numbers are totalled as 0.
+      Vector2(180.0, 0.0): "6"
    }
 
 If the face values are configured correctly, then the player will easily be able
@@ -135,8 +140,6 @@ dice. The total will be shown at the top of the context menu.
 
 If ``face_values`` is not configured, the dice will always report ``0`` as its
 value.
-
-If the same value needs to be present on multiple faces, a list may be specified rather than a single Vector2, as so:  ``-1: [Vector2(0.0, 0.0), Vector2(180.0, 0.0)]``
 
 .. _object-type-piece:
 

--- a/game/Scripts/AssetDB.gd
+++ b/game/Scripts/AssetDB.gd
@@ -1665,6 +1665,10 @@ func _is_valid_entry(pack: String, type: String, entry: Dictionary) -> bool:
 						_log_error("'face_values' value in entry is not an Array!")
 						return false
 					
+					if len(element_value) == 0:
+						_log_error("'face_values' value in entry is empty!")
+						return false
+					
 					for normal in element_value:
 						if typeof(normal) != TYPE_VECTOR3:
 							_log_error("'face_values' sub-value in entry is not a Vector3!")

--- a/game/Scripts/Game/CameraController.gd
+++ b/game/Scripts/Game/CameraController.gd
@@ -1256,10 +1256,14 @@ func _popup_piece_context_menu() -> void:
 	prev_num_items = _piece_context_menu.get_item_count()
 	
 	if _inheritance_has(inheritance, "Dice"):
-		var total = 0.0
-		var available_values = []
+		var single_dice_value := ""
+		var total := 0.0
+		var available_values := []
 		for dice in _selected_pieces:
-			total += dice.get_face_value()
+			var value: String = dice.get_face_value()
+			single_dice_value = value
+			if value.is_valid_float():
+				total += float(value)
 			
 			var face_value_dict: Dictionary = dice.piece_entry["face_values"]
 			for possible_value in face_value_dict.keys():
@@ -1267,13 +1271,21 @@ func _popup_piece_context_menu() -> void:
 					available_values.append(possible_value)
 		available_values.sort()
 		
-		var is_int = (round(total) == total)
-		if is_int:
-			_piece_context_menu.add_item(tr("Total: %d") % total)
+		if len(_selected_pieces) == 1:
+			# If there's a single piece, we should show value text (if any).
+			# (There are various symbol dice that benefit, i.e. Zombie Dice)
+			if single_dice_value == "":
+				_piece_context_menu.add_item(tr("Value: (None)"))
+			else:
+				_piece_context_menu.add_item(tr("Value: %s") % single_dice_value)
 		else:
-			_piece_context_menu.add_item(tr("Total: %f") % total)
+			var is_int = (round(total) == total)
+			if is_int:
+				_piece_context_menu.add_item(tr("Total: %d") % total)
+			else:
+				_piece_context_menu.add_item(tr("Total: %f") % total)
 		
-		var prev_value = 1
+		var prev_value := single_dice_value
 		if _dice_value_button.selected >= 0:
 			prev_value = _dice_value_button.get_item_metadata(
 					_dice_value_button.selected)

--- a/game/Scripts/Game/CameraController.gd
+++ b/game/Scripts/Game/CameraController.gd
@@ -2535,7 +2535,7 @@ func _on_SetDiceValueButton_pressed():
 			if not face_value_dict.has(value_to_set):
 				continue
 			
-			var face_value_normal: Vector3 = face_value_dict[value_to_set]
+			var face_value_normal: Vector3 = face_value_dict[value_to_set][0]
 			
 			var rotation_quat: Quat
 			if face_value_normal.is_equal_approx(Vector3.UP):

--- a/game/Scripts/Game/Pieces/Dice.gd
+++ b/game/Scripts/Game/Pieces/Dice.gd
@@ -40,11 +40,12 @@ func get_face_value() -> float:
 	var max_dot = -1.0
 	var closest_value = 0
 	for value in face_values:
-		var normal = face_values[value]
-		var dot = transform.basis.xform(normal).dot(Vector3.UP)
-		if dot > max_dot:
-			max_dot = dot
-			closest_value = value
+		var normals: Array = face_values[value]
+		for normal in normals:
+			var dot = transform.basis.xform(normal).dot(Vector3.UP)
+			if dot > max_dot:
+				max_dot = dot
+				closest_value = value
 	
 	return closest_value
 

--- a/game/Scripts/Game/Pieces/Dice.gd
+++ b/game/Scripts/Game/Pieces/Dice.gd
@@ -31,14 +31,14 @@ export(Resource) var shake_sounds
 var _rng = RandomNumberGenerator.new()
 
 # Get the value of the face that is currently pointed upwards.
-# Returns: The top face's value, 0 if no values are configured.
-func get_face_value() -> float:
+# Returns: The top face's value, the empty string if no values are configured.
+func get_face_value() -> String:
 	var face_values: Dictionary = piece_entry["face_values"]
 	if face_values.empty():
-		return 0.0
+		return ""
 	
 	var max_dot = -1.0
-	var closest_value = 0
+	var closest_value: String = "0"
 	for value in face_values:
 		var normals: Array = face_values[value]
 		for normal in normals:


### PR DESCRIPTION
**Changes**

* face_values can now have the keys and values swapped, as in 0.2.0. Internal representation is a dictionary of values (as strings) to array of Vector3 normals. Array mustn't be empty. The first vector will be used as the rotation when setting the value.
* Removed restriction on value count matching dice sides. (While the total amount of normals could be checked, IMO this 
restriction is arbitrary.)
* Face values are arbitrary; they are now stringified during load. Numbers are parsed when totalling requires it.
* When only a single dice is selected, the Total indicator instead now says Value, and the value given is "raw" (i.e. for named faces, this shows the face name).

**Fixes/Solves**
*What does this PR fix or solve? If applicable, put the issue number here.*

![image](https://github.com/drwhut/tabletop-club/assets/22304167/15504bcb-ed9c-43a2-b241-6c5e3aee2b73)
This screenshot is an example use-case: Fudge/FATE dice. These have two blanks (value 0), two + (value 1) symbols and two - (value -1) symbols.
The way you calculate rolls with these is to roll four at once, then total the values. Tabletop Club almost supports this perfectly, but without this PR, their values cannot be properly represented (at least without perhaps tricks like int/float differentiation) and thus it's not possible to get a total.

Numbers (as used)
```
face_values = {
    Vector2(0.0, 0.0): 1,
    Vector2(180.0, 0.0): 1,
    Vector2(0.0, 90.0): 0,
    Vector2(0.0, -90.0): 0,
    Vector2(-90.0, 0.0): -1,
    Vector2(90.0, 0.0): -1
}
```

Names (as an example)
```
face_values = {
    Vector2(0.0, 0.0): "+",
    Vector2(180.0, 0.0): "+",
    Vector2(0.0, 90.0): " ",
    Vector2(0.0, -90.0): " ",
    Vector2(-90.0, 0.0): "-",
    Vector2(90.0, 0.0): "-"
}
```

This also mostly helps #209 (though it's not possible to specify a numeric value for a named value).

_**NOTE:** Make sure this PR goes to the `master` branch! If this fix applies to
previously released versions, then the commits will be cherry-picked afterwards._
Done.