### PR TITLE
Docs: Add Flatpak log directory & asset troubleshooting paragraph

### DIFF
--- a/docs/custom_assets/tutorials/create_asset_pack.rst
+++ b/docs/custom_assets/tutorials/create_asset_pack.rst
@@ -33,3 +33,11 @@ Once you have added what you want to your asset pack, you can either restart the
 game, or go to :guilabel:`Options` > :guilabel:`General`, and click
 :guilabel:`Reimport Assets` to have the game import everything you've added so
 you can use it in-game!
+
+If your asset pack doesn't appear, try restarting the entire game.
+If that doesn't help either, an error might have occured when trying to import it.
+You can see what went wrong by checking the import log on the main-menu screen,
+click the leftmost button on the bottom of the screen, labeled with an exclamation
+point ``(!)`` to open it. If all else fails, searching for "ERROR" or your
+AssetPack's name in the latest logfile (see :ref:`ways_to_contribute`) can show
+more details of what went wrong.

--- a/docs/general/contributing/ways_to_contribute.rst
+++ b/docs/general/contributing/ways_to_contribute.rst
@@ -28,6 +28,7 @@ find the game logs in the following folders:
 * Windows: ``%APPDATA%/Tabletop Club/logs/``
 * macOS: ``~/Library/Application Support/Tabletop Club/logs``
 * Linux: ``~/.local/share/Tabletop Club/logs/``
+* Linux using FlatPak: ``~/.var/app/io.itch.drwhut.TabletopClub/data/Tabletop Club/logs``
 
 .. hint::
 


### PR DESCRIPTION
**Fixes/Solves**
Adds the path to the log directory for Flatpak users, which is different from the regular logfile directory. Also adds paragraph that can help Asset Pack creators who might not be aware of how to find import errors.